### PR TITLE
Fix a console error occurring due to line break in string literal

### DIFF
--- a/src/templates/_components/fields/formfields/notes/input.twig
+++ b/src/templates/_components/fields/formfields/notes/input.twig
@@ -33,8 +33,7 @@
 
     var headingDiv = $('#' + '{{ id }}-field' + ' .heading label');
 
-    $(headingDiv).append('
-    <a href="#" class="sproutnotes-togglebtn icon menubtn"></a>');
+    $(headingDiv).append('<a href="#" class="sproutnotes-togglebtn icon menubtn"></a>');
 
     $('#' + '{{ id }}-field' + ' label').on('click', function() {
 


### PR DESCRIPTION
The line break in the string literal on the jQuery `.append` causes a JavaScript error that causes many problems in the Craft control panel. This PR removes the line break which fixes the issue.

Screenshot of old code with line break:

![screenshot_2](https://user-images.githubusercontent.com/3803475/53265664-6ba4a700-36a4-11e9-96bb-08285f532910.png)

Screenshots of error occurring (note a completely unrelated field called content, which is a redactor field, is not rendering because of this JS error):

![screenshot_4](https://user-images.githubusercontent.com/3803475/53265713-8b3bcf80-36a4-11e9-8c61-fd3a8d988a44.png)

![screenshot_5](https://user-images.githubusercontent.com/3803475/53265723-91ca4700-36a4-11e9-8438-5b30cfacbc80.png)
