### PR TITLE
Set 'commerceguys/addressing' version to '1.3.0'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   },
   "require": {
     "craftcms/cms": "^3.1.0",
-    "commerceguys/addressing": "^1.0.6",
+    "commerceguys/addressing": "1.3.0",
     "giggsey/libphonenumber-for-php": "^8.12.4"
   },
   "autoload": {


### PR DESCRIPTION
Hi,

For the package: https://github.com/commerceguys/addressing, it introduces a breaking change for this package in version [v1.4.0](https://github.com/commerceguys/addressing/releases/tag/v1.4.0) (it includes type hints).

This causes issues with your [Sprout Form plugin](https://github.com/barrelstrength/craft-sprout-forms/issues/609). It throws a type error when rendering the address field.

I've specified the exact version to 1.3.0 as a fix. 